### PR TITLE
routeros: file-name should in quotes in newer (7.18) version

### DIFF
--- a/deploy/routeros.sh
+++ b/deploy/routeros.sh
@@ -144,8 +144,8 @@ source=\"/certificate remove [ find name=$_cdomain.cer_0 ];\
 \n/certificate remove [ find name=$_cdomain.cer_1 ];\
 \n/certificate remove [ find name=$_cdomain.cer_2 ];\
 \ndelay 1;\
-\n/certificate import file-name=$_cdomain.cer passphrase=\\\"\\\";\
-\n/certificate import file-name=$_cdomain.key passphrase=\\\"\\\";\
+\n/certificate import file-name=\\\"$_cdomain.cer\\\" passphrase=\\\"\\\";\
+\n/certificate import file-name=\\\"$_cdomain.key\\\" passphrase=\\\"\\\";\
 \ndelay 1;\
 \n:do {/file remove $_cdomain.cer; } on-error={ }\
 \n:do {/file remove $_cdomain.key; } on-error={ }\


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

https://github.com/acmesh-official/acme.sh/issues/2344#issuecomment-2698400790

in newer version of routeros , file-name should in quotes in scripts